### PR TITLE
add support for spaces as indentation

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -88,6 +88,11 @@ func (p *parser) next() bool {
 		p.line = strings.TrimSuffix(s, "\n")
 	}
 
+        // Substitute all leading sets of 4 spaces with tabs
+        for i := 0; strings.HasPrefix(p.line[i:], "    "); i++ {
+                p.line = p.line[:i] + "\t" + p.line[i+4:]
+        }
+
 	// Less indenting than expected. Let caller stop, returning to its caller for lower-level indent.
 	r := strings.HasPrefix(p.line, p.prefix)
 	return r


### PR DESCRIPTION
Sounded like you wouldn't mind having support for spaces as indentation on this: https://github.com/mjl-/mox/issues/319

I would too, so here it is.

First thing i've written in go, so it might be bad or slow.

There should probably be written some tests for it, but i'm sure someone else might have a better understanding of that whole process, than me.

Documentation should probably also be updated.

I set it to 4 spaces, it seems like a sensible amount.
If you want it variable or a static 8 or 2 spaces, then do that, i just want it to be spaces so i can use it in heredocs.
